### PR TITLE
Reorder dropped argument list

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -186,8 +186,8 @@ end
 Called whenever any object is dropped by a player.
 
 !!!info "onObjectDrop(player_color, dropped_object)"
-	* [<span class="tag obj"></span>](/types)&nbsp;**dropped_object**: The Object in game which was dropped.
 	* [<span class="tag str"></span>](/types)&nbsp;**player_color**: [Player Color](player-color) of the Player who dropped the Object.
+	* [<span class="tag obj"></span>](/types)&nbsp;**dropped_object**: The Object in game which was dropped.
 
 ``` Lua
 function onObjectDrop(colorName, obj)


### PR DESCRIPTION
The official had the argments for onObjectDropped in the wrong order, and the argument list too.
The signature for the function is already corrected, however the listing of the arguments was still in the wrong order. This fixes that.